### PR TITLE
add data attribute for preventing callback

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -11,7 +11,12 @@ const getLocalPathname = a =>
 export default onInternalNav => e => {
   if (e.button === 0 && !e.ctrlKey && !e.shiftKey && !e.altKey && !e.metaKey) {
     const aTag = findA(e.target)
-    if (aTag && aTag.target !== '_blank' && aTag.target !== '_external') {
+    if (
+      aTag &&
+      aTag.target !== '_blank' &&
+      aTag.target !== '_external' &&
+      aTag.getAttribute('data-static-link') !== 'false'
+    ) {
       const url = getLocalPathname(aTag)
       if (url) {
         e.preventDefault()

--- a/test.js
+++ b/test.js
@@ -16,7 +16,8 @@ const getTarget = ({
     {
       tagName,
       href,
-      parentElement: {}
+      parentElement: {},
+      getAttribute: () => {}
     },
     other
   )
@@ -38,7 +39,7 @@ const getEvent = ({
   )
 
 test('test nav helper', t => {
-  t.plan(3)
+  t.plan(4)
   setHost(baseHost)
   let called = 0
   const fn = navHelper(url => {
@@ -50,6 +51,9 @@ test('test nav helper', t => {
       t.equal(url, '/hi')
       return
     } else if (called === 3) {
+      t.equal(url, '/hi')
+      return
+    } else if (called === 4) {
       t.equal(url, '/done')
       t.end()
       return
@@ -61,6 +65,15 @@ test('test nav helper', t => {
   fn(getEvent({ other: { altKey: true } }))
   fn(getEvent({ target: getTarget({ other: { target: '_blank' } }) }))
   fn(getEvent({ target: getTarget({ other: { target: '_external' } }) }))
+  fn(
+    getEvent({
+      target: getTarget({
+        other: {
+          getAttribute: () => 'false'
+        }
+      })
+    })
+  )
 
   // the following *should* result in callbacks
   fn(getEvent())
@@ -73,6 +86,15 @@ test('test nav helper', t => {
           }
         }
       }
+    })
+  )
+  fn(
+    getEvent({
+      target: getTarget({
+        other: {
+          getAttribute: () => 'true'
+        }
+      })
     })
   )
   fn(getEvent({ href: 'http://' + baseHost + '/done' }))


### PR DESCRIPTION
I noticed that adding `target="external" Chrome and Safari (at least) open the link in a new tab. This seems to be the correct behavior for an unknown `target` type.

I added an attribute check for `data-static-link` on the target node. It's an explicit `"false"` check so the attraction could be added on its own or used with some logic - `data-static-link= !!isExternal`. 

This should enable a semantic way to prevent the callback and keep the user on the current tab.